### PR TITLE
Implement auth flow and astronomy home UI

### DIFF
--- a/FinalProject/AppRootView.swift
+++ b/FinalProject/AppRootView.swift
@@ -1,0 +1,28 @@
+//
+//  AppRootView.swift
+//  FinalProject
+//
+//  Created by Codex on 4/15/26.
+//
+
+import SwiftUI
+
+// App shell decides whether the user sees auth or the signed-in experience.
+struct AppRootView: View {
+    @StateObject private var viewModel = AppViewModel()
+
+    var body: some View {
+        ZStack {
+            AppBackgroundView()
+
+            Group {
+                if viewModel.currentUser == nil {
+                    AuthScreen(viewModel: viewModel)
+                } else {
+                    HomeScreen(viewModel: viewModel)
+                }
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+}

--- a/FinalProject/AppViewModel.swift
+++ b/FinalProject/AppViewModel.swift
@@ -1,0 +1,87 @@
+//
+//  AppViewModel.swift
+//  FinalProject
+//
+//  Created by Codex on 4/15/26.
+//
+
+import Combine
+import SwiftUI
+
+// Central view model keeps auth state and mock content in one place for this first build.
+@MainActor
+final class AppViewModel: ObservableObject {
+    @Published var currentUser: UserProfile?
+    @Published var authMode: AuthMode = .login
+    @Published var isLoading = false
+    @Published var errorMessage = ""
+    @Published var loginEmail = ""
+    @Published var loginPassword = ""
+    @Published var signUpUsername = ""
+    @Published var signUpEmail = ""
+    @Published var signUpPassword = ""
+    @Published var confirmPassword = ""
+    @Published var selectedTab: HomeTab = .home
+
+    let authService = AstronomyAuthService()
+    let visibleObjects = CelestialObject.sampleData
+    let upcomingEvents = EventCard.sampleData
+    let feedPosts = FeedPost.sampleData
+
+    func login() async {
+        errorMessage = ""
+
+        guard !loginEmail.isEmpty, !loginPassword.isEmpty else {
+            errorMessage = "Enter your email and password."
+            return
+        }
+
+        await runAuthAction {
+            currentUser = try await authService.login(email: loginEmail, password: loginPassword)
+        }
+    }
+
+    func signUp() async {
+        errorMessage = ""
+
+        guard !signUpUsername.isEmpty, !signUpEmail.isEmpty, !signUpPassword.isEmpty else {
+            errorMessage = "Complete every sign up field."
+            return
+        }
+
+        guard signUpPassword == confirmPassword else {
+            errorMessage = "Passwords do not match."
+            return
+        }
+
+        await runAuthAction {
+            currentUser = try await authService.signUp(
+                username: signUpUsername,
+                email: signUpEmail,
+                password: signUpPassword
+            )
+        }
+    }
+
+    func signOut() {
+        // Reset state so the app returns to the login view cleanly.
+        currentUser = nil
+        loginPassword = ""
+        signUpPassword = ""
+        confirmPassword = ""
+        selectedTab = .home
+        authMode = .login
+    }
+
+    private func runAuthAction(_ action: () async throws -> Void) async {
+        isLoading = true
+
+        do {
+            try await action()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+}

--- a/FinalProject/AuthScreen.swift
+++ b/FinalProject/AuthScreen.swift
@@ -1,0 +1,149 @@
+//
+//  AuthScreen.swift
+//  FinalProject
+//
+//  Created by Codex on 4/15/26.
+//
+
+import SwiftUI
+
+struct AuthScreen: View {
+    @ObservedObject var viewModel: AppViewModel
+
+    var body: some View {
+        ScrollView(showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 24) {
+                header
+                authPicker
+                authCard
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 32)
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Astronomy")
+                .font(.system(size: 18, weight: .semibold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.72))
+
+            Text(viewModel.authMode == .login ? "Explore the night sky." : "Create your stargazing account.")
+                .font(.system(size: 34, weight: .bold, design: .rounded))
+                .foregroundStyle(.white)
+
+            Text("Track visible planets, save celestial events, and join a community built around the sky above you.")
+                .font(.system(size: 15, weight: .medium, design: .rounded))
+                .foregroundStyle(.white.opacity(0.74))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.top, 20)
+    }
+
+    private var authPicker: some View {
+        HStack(spacing: 10) {
+            ForEach(AuthMode.allCases, id: \.self) { mode in
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        viewModel.authMode = mode
+                        viewModel.errorMessage = ""
+                    }
+                } label: {
+                    Text(mode.rawValue)
+                        .font(.system(size: 15, weight: .semibold, design: .rounded))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(
+                            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                .fill(viewModel.authMode == mode ? Color.white.opacity(0.18) : Color.white.opacity(0.06))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                .stroke(Color.white.opacity(viewModel.authMode == mode ? 0.4 : 0.12), lineWidth: 1)
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var authCard: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text(viewModel.authMode == .login ? "Welcome back" : "Start your account")
+                .font(.system(size: 24, weight: .bold, design: .rounded))
+                .foregroundStyle(.white)
+
+            if viewModel.authMode == .login {
+                Group {
+                    LabeledInputField(title: "Email", text: $viewModel.loginEmail, prompt: "name@email.com", keyboardType: .emailAddress)
+                    LabeledSecureField(title: "Password", text: $viewModel.loginPassword, prompt: "Enter your password")
+                }
+            } else {
+                Group {
+                    LabeledInputField(title: "Username", text: $viewModel.signUpUsername, prompt: "Choose a username")
+                    LabeledInputField(title: "Email", text: $viewModel.signUpEmail, prompt: "name@email.com", keyboardType: .emailAddress)
+                    LabeledSecureField(title: "Password", text: $viewModel.signUpPassword, prompt: "Create a password")
+                    LabeledSecureField(title: "Confirm Password", text: $viewModel.confirmPassword, prompt: "Re-enter password")
+                }
+            }
+
+            if !viewModel.errorMessage.isEmpty {
+                Text(viewModel.errorMessage)
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundStyle(Color(red: 1.0, green: 0.72, blue: 0.72))
+                    .padding(12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.red.opacity(0.14), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            }
+
+            Button {
+                Task {
+                    if viewModel.authMode == .login {
+                        await viewModel.login()
+                    } else {
+                        await viewModel.signUp()
+                    }
+                }
+            } label: {
+                HStack {
+                    Spacer()
+
+                    if viewModel.isLoading {
+                        ProgressView()
+                            .tint(.white)
+                    } else {
+                        Text(viewModel.authMode == .login ? "Log In" : "Create Account")
+                            .font(.system(size: 16, weight: .bold, design: .rounded))
+                    }
+
+                    Spacer()
+                }
+                .padding(.vertical, 16)
+                .background(
+                    LinearGradient(
+                        colors: [Color(red: 0.46, green: 0.58, blue: 0.79), Color(red: 0.20, green: 0.29, blue: 0.46)],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .disabled(viewModel.isLoading)
+
+            Text("`databaseURL` is intentionally blank right now. Auth uses a local mock session until you wire in the backend.")
+                .font(.system(size: 12, weight: .medium, design: .rounded))
+                .foregroundStyle(.white.opacity(0.56))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(22)
+        .background(
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .fill(Color.white.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .stroke(Color.white.opacity(0.14), lineWidth: 1)
+        )
+    }
+}

--- a/FinalProject/AuthService.swift
+++ b/FinalProject/AuthService.swift
@@ -1,0 +1,87 @@
+//
+//  AuthService.swift
+//  FinalProject
+//
+//  Created by Codex on 4/15/26.
+//
+
+import Foundation
+
+// Keep the backend URL empty until the real database/API is ready.
+enum AppConfiguration {
+    static let databaseURL = ""
+}
+
+enum AuthError: LocalizedError {
+    case invalidURL
+    case invalidResponse
+    case missingToken
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Add your database URL before connecting live auth."
+        case .invalidResponse:
+            return "The server response could not be read."
+        case .missingToken:
+            return "The server did not return a valid user session."
+        }
+    }
+}
+
+// Service is ready for a real backend, but falls back to local mock auth while the URL is empty.
+struct AstronomyAuthService {
+    func login(email: String, password: String) async throws -> UserProfile {
+        if AppConfiguration.databaseURL.isEmpty {
+            try await Task.sleep(for: .milliseconds(700))
+            return UserProfile(id: UUID(), username: mockUsername(from: email), email: email)
+        }
+
+        return try await performAuthRequest(
+            path: "/login",
+            payload: ["email": email, "password": password]
+        )
+    }
+
+    func signUp(username: String, email: String, password: String) async throws -> UserProfile {
+        if AppConfiguration.databaseURL.isEmpty {
+            try await Task.sleep(for: .milliseconds(700))
+            return UserProfile(id: UUID(), username: username, email: email)
+        }
+
+        return try await performAuthRequest(
+            path: "/register",
+            payload: ["username": username, "email": email, "password": password]
+        )
+    }
+
+    private func performAuthRequest(path: String, payload: [String: String]) async throws -> UserProfile {
+        guard let url = URL(string: AppConfiguration.databaseURL + path) else {
+            throw AuthError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(payload)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, 200..<300 ~= httpResponse.statusCode else {
+            throw AuthError.invalidResponse
+        }
+
+        let authResponse = try JSONDecoder().decode(AuthResponse.self, from: data)
+
+        guard let user = authResponse.user else {
+            throw AuthError.missingToken
+        }
+
+        return user
+    }
+
+    private func mockUsername(from email: String) -> String {
+        // A simple fallback keeps the app usable before backend wiring is added.
+        email.split(separator: "@").first.map(String.init) ?? "Astronomy User"
+    }
+}

--- a/FinalProject/ContentView.swift
+++ b/FinalProject/ContentView.swift
@@ -7,18 +7,15 @@
 
 import SwiftUI
 
+// Root container stays intentionally small and delegates to the app shell.
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-        }
-        .padding()
+        AppRootView()
     }
 }
 
-#Preview {
-    ContentView()
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
 }

--- a/FinalProject/HomeScreen.swift
+++ b/FinalProject/HomeScreen.swift
@@ -1,0 +1,225 @@
+//
+//  HomeScreen.swift
+//  FinalProject
+//
+//  Created by Codex on 4/15/26.
+//
+
+import SwiftUI
+
+struct HomeScreen: View {
+    @ObservedObject var viewModel: AppViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 22) {
+                    homeHeader
+                    skyHero
+                    tonightSection
+                    eventsSection
+                    feedSection
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 28)
+                .padding(.bottom, 24)
+            }
+
+            bottomNavigation
+                .padding(.horizontal, 20)
+                .padding(.bottom, 20)
+        }
+    }
+
+    private var homeHeader: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Home")
+                    .font(.system(size: 30, weight: .bold, design: .rounded))
+                    .foregroundStyle(.white)
+
+                Text("Welcome, \(viewModel.currentUser?.username ?? "Explorer")")
+                    .font(.system(size: 15, weight: .medium, design: .rounded))
+                    .foregroundStyle(.white.opacity(0.68))
+            }
+
+            Spacer()
+
+            Button("Log Out") {
+                viewModel.signOut()
+            }
+            .font(.system(size: 13, weight: .bold, design: .rounded))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(Color.white.opacity(0.08), in: Capsule())
+        }
+    }
+
+    private var skyHero: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text("Tonight's Sky")
+                .font(.system(size: 20, weight: .bold, design: .rounded))
+                .foregroundStyle(.white)
+
+            ZStack(alignment: .bottomLeading) {
+                RoundedRectangle(cornerRadius: 28, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: [Color(red: 0.38, green: 0.44, blue: 0.56), Color(red: 0.08, green: 0.10, blue: 0.18)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(height: 230)
+
+                // Decorative stars help the card feel closer to the provided mockup.
+                StarFieldOverlay()
+                    .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Clear conditions for Jupiter and Vega")
+                        .font(.system(size: 24, weight: .bold, design: .rounded))
+                        .foregroundStyle(.white)
+
+                    Text("Use the sky map after sunset for the strongest visibility window.")
+                        .font(.system(size: 14, weight: .medium, design: .rounded))
+                        .foregroundStyle(.white.opacity(0.74))
+                }
+                .padding(22)
+            }
+        }
+    }
+
+    private var tonightSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Visible Stars / Planets")
+                .font(.system(size: 20, weight: .bold, design: .rounded))
+                .foregroundStyle(.white)
+
+            ForEach(viewModel.visibleObjects) { object in
+                InfoRowCard(
+                    title: object.name,
+                    subtitle: object.type,
+                    detail: object.timeVisible,
+                    sfSymbol: object.sfSymbol
+                )
+            }
+        }
+    }
+
+    private var eventsSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Upcoming Events")
+                .font(.system(size: 20, weight: .bold, design: .rounded))
+                .foregroundStyle(.white)
+
+            ForEach(viewModel.upcomingEvents) { event in
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text(event.title)
+                            .font(.system(size: 17, weight: .bold, design: .rounded))
+                            .foregroundStyle(.white)
+
+                        Spacer()
+
+                        Text(event.date)
+                            .font(.system(size: 14, weight: .bold, design: .rounded))
+                            .foregroundStyle(Color(red: 0.73, green: 0.83, blue: 1.0))
+                    }
+
+                    Text(event.detail)
+                        .font(.system(size: 14, weight: .medium, design: .rounded))
+                        .foregroundStyle(.white.opacity(0.7))
+                }
+                .padding(18)
+                .background(Color.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 22, style: .continuous)
+                        .stroke(Color.white.opacity(0.12), lineWidth: 1)
+                )
+            }
+        }
+    }
+
+    private var feedSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Community Feed")
+                .font(.system(size: 20, weight: .bold, design: .rounded))
+                .foregroundStyle(.white)
+
+            ForEach(viewModel.feedPosts) { post in
+                VStack(alignment: .leading, spacing: 14) {
+                    HStack {
+                        Circle()
+                            .fill(Color.white.opacity(0.20))
+                            .frame(width: 42, height: 42)
+                            .overlay(Image(systemName: "person.fill").foregroundStyle(.white.opacity(0.85)))
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(post.username)
+                                .font(.system(size: 16, weight: .bold, design: .rounded))
+                                .foregroundStyle(.white)
+
+                            Text("2h ago")
+                                .font(.system(size: 12, weight: .medium, design: .rounded))
+                                .foregroundStyle(.white.opacity(0.55))
+                        }
+
+                        Spacer()
+                    }
+
+                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                        .fill(LinearGradient(colors: post.gradient, startPoint: .topLeading, endPoint: .bottomTrailing))
+                        .frame(height: 180)
+                        .overlay(StarFieldOverlay().opacity(0.7).clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous)))
+
+                    Text(post.caption)
+                        .font(.system(size: 15, weight: .medium, design: .rounded))
+                        .foregroundStyle(.white.opacity(0.78))
+
+                    HStack(spacing: 18) {
+                        Label("\(post.likes)", systemImage: "heart.fill")
+                        Label("\(post.comments)", systemImage: "message.fill")
+                    }
+                    .font(.system(size: 13, weight: .bold, design: .rounded))
+                    .foregroundStyle(.white.opacity(0.7))
+                }
+                .padding(18)
+                .background(Color.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 28, style: .continuous)
+                        .stroke(Color.white.opacity(0.12), lineWidth: 1)
+                )
+            }
+        }
+    }
+
+    private var bottomNavigation: some View {
+        HStack {
+            ForEach(HomeTab.allCases, id: \.self) { tab in
+                Button {
+                    viewModel.selectedTab = tab
+                } label: {
+                    VStack(spacing: 7) {
+                        Image(systemName: tab.icon)
+                            .font(.system(size: 17, weight: .semibold))
+
+                        Text(tab.rawValue)
+                            .font(.system(size: 11, weight: .bold, design: .rounded))
+                    }
+                    .foregroundStyle(viewModel.selectedTab == tab ? .white : .white.opacity(0.48))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 10)
+        .background(Color.white.opacity(0.08), in: Capsule())
+        .overlay(
+            Capsule()
+                .stroke(Color.white.opacity(0.12), lineWidth: 1)
+        )
+    }
+}

--- a/FinalProject/Models.swift
+++ b/FinalProject/Models.swift
@@ -1,0 +1,80 @@
+//
+//  Models.swift
+//  FinalProject
+//
+//  Created by Codex on 4/15/26.
+//
+
+import SwiftUI
+
+enum AuthMode: String, CaseIterable {
+    case login = "Log In"
+    case signUp = "Sign Up"
+}
+
+enum HomeTab: String, CaseIterable {
+    case home = "Home"
+    case sky = "Sky"
+    case feed = "Feed"
+    case profile = "Profile"
+
+    var icon: String {
+        switch self {
+        case .home: return "house.fill"
+        case .sky: return "sparkles"
+        case .feed: return "rectangle.stack.fill"
+        case .profile: return "person.fill"
+        }
+    }
+}
+
+struct UserProfile: Codable, Identifiable {
+    let id: UUID
+    let username: String
+    let email: String
+}
+
+struct CelestialObject: Identifiable {
+    let id = UUID()
+    let name: String
+    let type: String
+    let timeVisible: String
+    let sfSymbol: String
+
+    static let sampleData: [CelestialObject] = [
+        .init(name: "Jupiter", type: "Planet", timeVisible: "Visible until 3:10 AM", sfSymbol: "globe.americas.fill"),
+        .init(name: "Cygnus", type: "Constellation", timeVisible: "Best viewed after 9:30 PM", sfSymbol: "sparkles"),
+        .init(name: "Vega", type: "Star", timeVisible: "High in the northeast", sfSymbol: "star.fill")
+    ]
+}
+
+struct EventCard: Identifiable {
+    let id = UUID()
+    let title: String
+    let date: String
+    let detail: String
+
+    static let sampleData: [EventCard] = [
+        .init(title: "Meteor Shower", date: "July 12", detail: "Peak visibility after midnight with clear skies."),
+        .init(title: "Saturn Rise", date: "July 18", detail: "Low eastern horizon viewing just before dawn."),
+        .init(title: "Moonless Sky", date: "July 22", detail: "Best night this month for deep-sky photography.")
+    ]
+}
+
+struct FeedPost: Identifiable {
+    let id = UUID()
+    let username: String
+    let caption: String
+    let likes: Int
+    let comments: Int
+    let gradient: [Color]
+
+    static let sampleData: [FeedPost] = [
+        .init(username: "stargazer_ana", caption: "Caught Jupiter breaking through thin clouds tonight.", likes: 128, comments: 24, gradient: [Color(red: 0.36, green: 0.45, blue: 0.62), Color(red: 0.13, green: 0.17, blue: 0.27)]),
+        .init(username: "cosmic.miles", caption: "Tried a longer exposure for Cygnus and finally got a clean frame.", likes: 94, comments: 11, gradient: [Color(red: 0.48, green: 0.53, blue: 0.63), Color(red: 0.19, green: 0.22, blue: 0.33)])
+    ]
+}
+
+struct AuthResponse: Codable {
+    let user: UserProfile?
+}

--- a/FinalProject/SharedComponents.swift
+++ b/FinalProject/SharedComponents.swift
@@ -1,0 +1,144 @@
+//
+//  SharedComponents.swift
+//  FinalProject
+//
+//  Created by Codex on 4/15/26.
+//
+
+import SwiftUI
+
+// Reusable field keeps the forms visually consistent.
+struct LabeledInputField: View {
+    let title: String
+    @Binding var text: String
+    let prompt: String
+    var keyboardType: UIKeyboardType = .default
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.system(size: 13, weight: .bold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.72))
+
+            TextField("", text: $text, prompt: Text(prompt).foregroundStyle(.white.opacity(0.30)))
+                .textInputAutocapitalization(.never)
+                .keyboardType(keyboardType)
+                .autocorrectionDisabled()
+                .padding(16)
+                .background(Color.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .stroke(Color.white.opacity(0.10), lineWidth: 1)
+                )
+                .foregroundStyle(.white)
+        }
+    }
+}
+
+struct LabeledSecureField: View {
+    let title: String
+    @Binding var text: String
+    let prompt: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.system(size: 13, weight: .bold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.72))
+
+            SecureField("", text: $text, prompt: Text(prompt).foregroundStyle(.white.opacity(0.30)))
+                .textInputAutocapitalization(.never)
+                .padding(16)
+                .background(Color.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .stroke(Color.white.opacity(0.10), lineWidth: 1)
+                )
+                .foregroundStyle(.white)
+        }
+    }
+}
+
+struct InfoRowCard: View {
+    let title: String
+    let subtitle: String
+    let detail: String
+    let sfSymbol: String
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Image(systemName: sfSymbol)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(Color(red: 0.79, green: 0.87, blue: 1.0))
+                .frame(width: 44, height: 44)
+                .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.system(size: 16, weight: .bold, design: .rounded))
+                    .foregroundStyle(.white)
+
+                Text(subtitle)
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundStyle(.white.opacity(0.58))
+            }
+
+            Spacer()
+
+            Text(detail)
+                .font(.system(size: 12, weight: .semibold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.66))
+                .multilineTextAlignment(.trailing)
+        }
+        .padding(16)
+        .background(Color.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .stroke(Color.white.opacity(0.12), lineWidth: 1)
+        )
+    }
+}
+
+struct AppBackgroundView: View {
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [Color(red: 0.05, green: 0.07, blue: 0.12), Color(red: 0.10, green: 0.13, blue: 0.21), Color.black],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            Circle()
+                .fill(Color(red: 0.47, green: 0.56, blue: 0.76).opacity(0.20))
+                .frame(width: 280)
+                .blur(radius: 60)
+                .offset(x: -120, y: -280)
+
+            Circle()
+                .fill(Color.white.opacity(0.07))
+                .frame(width: 240)
+                .blur(radius: 50)
+                .offset(x: 120, y: 320)
+        }
+    }
+}
+
+struct StarFieldOverlay: View {
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack {
+                ForEach(0..<22, id: \.self) { index in
+                    Circle()
+                        .fill(Color.white.opacity(index.isMultiple(of: 3) ? 0.7 : 0.35))
+                        .frame(width: index.isMultiple(of: 4) ? 4 : 2, height: index.isMultiple(of: 4) ? 4 : 2)
+                        .position(
+                            x: CGFloat((index * 37) % Int(proxy.size.width)),
+                            y: CGFloat((index * 53) % Int(proxy.size.height))
+                        )
+                }
+            }
+        }
+        .allowsHitTesting(false)
+    }
+}


### PR DESCRIPTION
Made the skeleton of login and sign up page

## Summary by Sourcery

Introduce an app-wide root shell that switches between authentication and a new astronomy-themed home experience based on user session state.

New Features:
- Add an authentication screen with login and sign-up modes powered by a centralized app view model and mock auth service.
- Add an astronomy home screen showing tonight’s sky highlights, visible objects, upcoming events, and a community feed with bottom tab navigation.
- Introduce shared UI components for inputs, info cards, background, and decorative star overlays to unify the app’s visual style.

Enhancements:
- Replace the default ContentView placeholder with the new AppRootView for the main app entry point.

Chores:
- Add basic models and configuration scaffolding to support auth state, navigation tabs, and mock content data.