### PR TITLE
added Delete post feature

### DIFF
--- a/FinalProject/AppViewModel.swift
+++ b/FinalProject/AppViewModel.swift
@@ -43,6 +43,11 @@ final class AppViewModel: ObservableObject {
     @Published var displayedObjectSearchResults: [SearchableSkyObject] = []
     @Published var isObjectSearchLoading = false
     @Published var astronomyAPIErrorMessage = ""
+    @Published var isDeletingPosts = false
+    @Published var deleteErrorMessage = ""
+    @Published var profilePosts: [FeedPost] = []
+    @Published var isLoadingProfilePosts = false
+    private var profilePostsLastDocument: DocumentSnapshot?
     private var feedListener: ListenerRegistration?
 
     let authService = AstronomyAuthService()
@@ -281,7 +286,105 @@ final class AppViewModel: ObservableObject {
         }
     }
 
+    func deletePost(withID id: String) async -> String? {
+        guard currentUser != nil else { return "You must be signed in to delete a post." }
+        isDeletingPosts = true
+        deleteErrorMessage = ""
+        do {
+            try await db.collection("feedPosts").document(id).delete()
+            await MainActor.run {
+                self.feedPosts.removeAll { $0.id == id }
+            }
+            isDeletingPosts = false
+            return nil
+        } catch {
+            isDeletingPosts = false
+            deleteErrorMessage = error.localizedDescription
+            return error.localizedDescription
+        }
+    }
+
+    func deletePosts(withIDs ids: [String]) async -> String? {
+        guard currentUser != nil else { return "You must be signed in to delete posts." }
+        guard !ids.isEmpty else { return nil }
+        isDeletingPosts = true
+        deleteErrorMessage = ""
+        do {
+            let batch = db.batch()
+            let collection = db.collection("feedPosts")
+            for id in ids {
+                batch.deleteDocument(collection.document(id))
+            }
+            try await batch.commit()
+            await MainActor.run {
+                self.feedPosts.removeAll { ids.contains($0.id) }
+                self.profilePosts.removeAll { ids.contains($0.id) }
+            }
+            isDeletingPosts = false
+            return nil
+        } catch {
+            isDeletingPosts = false
+            deleteErrorMessage = error.localizedDescription
+            return error.localizedDescription
+        }
+    }
     
+    func resetProfilePostsPagination() {
+        profilePosts = []
+        profilePostsLastDocument = nil
+    }
+
+    func loadMoreProfilePosts(pageSize: Int = 20) async {
+        guard let currentUser else { return }
+        if isLoadingProfilePosts { return }
+        isLoadingProfilePosts = true
+        deleteErrorMessage = ""
+        var query: Query = db.collection("feedPosts")
+            .whereField("userID", isEqualTo: currentUser.id)
+            .order(by: "createdAt", descending: true)
+            .limit(to: pageSize)
+        if let last = profilePostsLastDocument {
+            query = query.start(afterDocument: last)
+        }
+        do {
+            let snapshot = try await query.getDocuments()
+            let newPosts: [FeedPost] = snapshot.documents.compactMap { document in
+                let data = document.data()
+                guard
+                    let userID = data["userID"] as? String,
+                    let username = data["username"] as? String,
+                    let caption = data["caption"] as? String,
+                    let createdAt = data["createdAt"] as? Timestamp,
+                    let likes = data["likes"] as? Int,
+                    let comments = data["comments"] as? Int
+                else { return nil }
+                let imageBase64 = data["imageBase64"] as? String
+                let decodedImageData = imageBase64.flatMap { Data(base64Encoded: $0) }
+                return FeedPost(
+                    id: document.documentID,
+                    userID: userID,
+                    username: username,
+                    caption: caption,
+                    createdAt: createdAt.dateValue(),
+                    likes: likes,
+                    comments: comments,
+                    gradient: [AstroTheme.primary.opacity(0.9), AstroTheme.secondary.opacity(0.8)],
+                    imageData: decodedImageData,
+                    imageBase64: imageBase64
+                )
+            }
+            await MainActor.run {
+                self.profilePosts.append(contentsOf: newPosts)
+                self.profilePostsLastDocument = snapshot.documents.last
+            }
+        } catch {
+            await MainActor.run {
+                self.deleteErrorMessage = error.localizedDescription
+            }
+        }
+        isLoadingProfilePosts = false
+    }
+
     func requestLocationAccess() {
         activeLocationName = nil
         locationManager.requestLocationAccess()
@@ -638,4 +741,3 @@ final class SkyLocationManager: NSObject, ObservableObject, CLLocationManagerDel
     
     
 }
-

--- a/FinalProject/EditPostsScreen.swift
+++ b/FinalProject/EditPostsScreen.swift
@@ -1,0 +1,171 @@
+import SwiftUI
+
+struct EditPostsScreen: View {
+    @ObservedObject var viewModel: AppViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var isSelecting = false
+    @State private var selectedIDs = Set<String>()
+
+    var body: some View {
+        List {
+            if viewModel.isLoadingProfilePosts && viewModel.profilePosts.isEmpty {
+                Section {
+                    HStack(spacing: 10) {
+                        ProgressView().tint(AstroTheme.primary)
+                        Text("Loading your posts...")
+                            .foregroundStyle(AstroTheme.muted)
+                    }
+                }
+            }
+
+            ForEach(viewModel.profilePosts) { post in
+                HStack(spacing: 12) {
+                    selectionIndicator(for: post.id)
+
+                    if let data = post.imageData, let uiImage = UIImage(data: data) {
+                        Image(uiImage: uiImage)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: 64, height: 64)
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    } else {
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .fill(LinearGradient(colors: post.gradient, startPoint: .topLeading, endPoint: .bottomTrailing))
+                            .frame(width: 64, height: 64)
+                            .overlay(StarFieldOverlay().opacity(0.6).clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous)))
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(post.caption)
+                            .font(.system(size: 15, weight: .semibold, design: .rounded))
+                            .foregroundStyle(.white)
+                            .lineLimit(2)
+                        Text(post.timestampText)
+                            .font(.system(size: 12, weight: .medium, design: .rounded))
+                            .foregroundStyle(AstroTheme.muted)
+                    }
+
+                    Spacer()
+
+                    if !isSelecting {
+                        Menu {
+                            Button(role: .destructive) {
+                                Task { await deleteSingle(postID: post.id) }
+                            } label: { Label("Delete", systemImage: "trash") }
+                        } label: {
+                            Image(systemName: "ellipsis")
+                                .font(.system(size: 16, weight: .bold))
+                                .foregroundStyle(AstroTheme.muted)
+                                .padding(4)
+                        }
+                    }
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    guard isSelecting else { return }
+                    toggleSelection(for: post.id)
+                }
+            }
+
+            if !viewModel.profilePosts.isEmpty {
+                Section {
+                    if viewModel.isLoadingProfilePosts {
+                        HStack(spacing: 10) {
+                            ProgressView().tint(AstroTheme.primary)
+                            Text("Loading more...")
+                                .foregroundStyle(AstroTheme.muted)
+                        }
+                    } else {
+                        Button {
+                            Task { await viewModel.loadMoreProfilePosts() }
+                        } label: {
+                            HStack {
+                                Spacer()
+                                Text("Load 20 more")
+                                    .font(.system(size: 14, weight: .bold, design: .rounded))
+                                Spacer()
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Edit Posts")
+        .toolbar { toolbarContent }
+        .task {
+            viewModel.resetProfilePostsPagination()
+            await viewModel.loadMoreProfilePosts()
+        }
+        .alert("Delete Posts", isPresented: Binding(get: { !viewModel.deleteErrorMessage.isEmpty }, set: { _ in viewModel.deleteErrorMessage = "" })) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(viewModel.deleteErrorMessage)
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .navigationBarLeading) {
+            if isSelecting {
+                Button("Cancel") { cancelSelection() }
+            }
+        }
+        ToolbarItem(placement: .navigationBarTrailing) {
+            if isSelecting {
+                Button(role: .destructive) {
+                    Task { await deleteSelected() }
+                } label: { Text("Delete (") + Text("\(selectedIDs.count)") + Text(")") }
+                .disabled(selectedIDs.isEmpty)
+            } else {
+                Button("Select") { isSelecting = true }
+            }
+        }
+    }
+
+    private func selectionIndicator(for id: String) -> some View {
+        Group {
+            if isSelecting {
+                Image(systemName: selectedIDs.contains(id) ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(selectedIDs.contains(id) ? AstroTheme.primary : AstroTheme.muted)
+                    .font(.system(size: 20, weight: .bold))
+            } else {
+                EmptyView()
+            }
+        }
+        .frame(width: isSelecting ? 24 : 0)
+    }
+
+    private func toggleSelection(for id: String) {
+        if selectedIDs.contains(id) {
+            selectedIDs.remove(id)
+        } else {
+            selectedIDs.insert(id)
+        }
+    }
+
+    private func cancelSelection() {
+        isSelecting = false
+        selectedIDs.removeAll()
+    }
+
+    private func deleteSingle(postID: String) async {
+        if let error = await viewModel.deletePost(withID: postID) {
+            await MainActor.run { viewModel.deleteErrorMessage = error }
+        }
+    }
+
+    private func deleteSelected() async {
+        let ids = Array(selectedIDs)
+        if let error = await viewModel.deletePosts(withIDs: ids) {
+            await MainActor.run { viewModel.deleteErrorMessage = error }
+        } else {
+            await MainActor.run {
+                cancelSelection()
+            }
+        }
+    }
+}
+

--- a/FinalProject/HomeScreen.swift
+++ b/FinalProject/HomeScreen.swift
@@ -404,6 +404,24 @@ struct HomeScreen: View {
                         }
 
                         Spacer()
+                        
+                        if viewModel.currentUser?.id == post.userID {
+                            Menu {
+                                Button(role: .destructive) {
+                                    Task {
+                                        _ = await viewModel.deletePost(withID: post.id)
+                                    }
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            } label: {
+                                Image(systemName: "ellipsis")
+                                    .font(.system(size: 16, weight: .bold))
+                                    .foregroundStyle(AstroTheme.muted)
+                                    .padding(8)
+                            }
+                            .accessibilityLabel("Post options")
+                        }
                     }
 
                     feedPostMedia(for: post)

--- a/FinalProject/ProfileScreen.swift
+++ b/FinalProject/ProfileScreen.swift
@@ -61,6 +61,11 @@ struct ProfileScreen: View {
                         }
                         .buttonStyle(.plain)
 
+                        NavigationLink(destination: EditPostsScreen(viewModel: viewModel)) {
+                            profileRow(icon: "square.and.pencil", title: "Edit Posts")
+                        }
+                        .buttonStyle(.plain)
+
                         profileRow(icon: "gearshape", title: "Settings")
                         profileRow(icon: "bell", title: "Notifications")
                         profileRow(icon: "lock.shield", title: "Privacy")
@@ -114,3 +119,4 @@ struct ProfileScreen: View {
         .surfaceCard()
     }
 }
+


### PR DESCRIPTION
user can delete their posts, from either the astro feed or through their profile, which now has an edit posts section.

## Summary by Sourcery

Add support for users to delete their own feed posts from both the main feed and a new profile edit view.

New Features:
- Allow users to delete individual posts directly from the home feed when they are the post owner.
- Introduce an Edit Posts screen in the profile where users can view, paginate through, and manage their own posts, including single and bulk deletion.

Enhancements:
- Extend the app view model with state and pagination for loading a user’s profile posts and with operations for deleting single or multiple posts, including basic error handling.